### PR TITLE
Flip Array.Alt to match order of stdlib

### DIFF
--- a/bastet/src/Array.re
+++ b/bastet/src/Array.re
@@ -65,7 +65,7 @@ module Monad: MONAD with type t('a) = array('a) = {
 
 module Alt: ALT with type t('a) = array('a) = {
   include Functor;
-  let alt = (a, b) => ArrayLabels.append(b, a);
+  let alt = (a, b) => ArrayLabels.append(a, b);
 };
 
 module Foldable: FOLDABLE with type t('a) = array('a) = {


### PR DESCRIPTION
In changing the implementation of `Array.Alt` from `Js.Array` to `ArrayLabels`, the order of concatenation got flipped, because:

```reason
ArrayLabels.append([|"a"|], [|"b", "c"|]); // [|"b", "c", "a"|]
Js.Array.concat([|"a"|], [|"b", "c"|]);    // [|"a", "b", "c"|]
```

This PR switches it back, so that `JsArray.Alt` and `Array.Alt` will be consistent.