### PR TITLE
Fix for Result Bi-/Traversable signatures

### DIFF
--- a/bastet/src/Result.re
+++ b/bastet/src/Result.re
@@ -40,10 +40,12 @@ module type FOLDABLE_F =
   (T: TYPE) => FOLDABLE with type t('a) = result('a, T.t);
 module type TRAVERSABLE_F =
   (T: TYPE, A: APPLICATIVE) =>
-   TRAVERSABLE with type t('a) = result('a, T.t);
+    TRAVERSABLE with
+      type t('a) = result('a, T.t) and
+      type applicative_t('a) = A.t('a);
+
 module type BITRAVERSABLE_F =
   (A: APPLICATIVE) =>
-
     BITRAVERSABLE with
       type t('a, 'b) = result('a, 'b) and
       type applicative_t('a) = A.t('a);
@@ -401,9 +403,7 @@ module Traversable: TRAVERSABLE_F =
       };
   };
 
-module Bitraversable = (A: APPLICATIVE) => {
-  module I = Infix.Apply(A);
-
+module Bitraversable: BITRAVERSABLE_F = (A: APPLICATIVE) => {
   type t('a, 'b) = result('a, 'b)
   and applicative_t('a) = A.t('a);
 


### PR DESCRIPTION
In reazen/relude#252, it was reported that the `applicative_t('a)` type couldn't unify in `Result.Bitraversable`. I think this is because the `Bitraversable` module was missing the `BITRAVERSABLE_F` signature. I also added the `applicative_t('a)` to the `TRAVERSABLE_F` signature, to make sure those types can be unified, and I deleted `Bitraversable.Infix` since it wasn't used and wasn't included in the module signature, so it couldn't be accessed.