### PR TITLE
Move `bisect_ppx` to npm `dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "author": "Risto Stevcev",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "bisect_ppx": "^2.1.0",
     "bs-stdlib-shims": "^0.1.0"
   },
   "devDependencies": {
-    "bisect_ppx": "^2.1.0",
     "bs-chai": "^1.0.1",
     "bs-jsverify": "0.10.0",
     "bs-mocha": "^1.0.0",


### PR DESCRIPTION
Because this module is in the bsconfig `dependencies` list, it is required to be present for a successful build. Moving it to the npm `dependencies` will ensure that it is installed when `bs-bastet` is installed.

resolves #26