### PR TITLE
Address difference in JsArray and Array argument orders

### DIFF
--- a/bastet_js/src/JsArray.re
+++ b/bastet_js/src/JsArray.re
@@ -44,7 +44,7 @@ module Apply: APPLY with type t('a) = array('a) = {
 module Monad: MONAD with type t('a) = array('a) = {
   include Array.Applicative;
   let flat_map = (x, f) =>
-    Js.Array.reduce((acc, a) => Js.Array.concat(acc, f(a)), [||], x);
+    Js.Array.reduce((acc, a) => Js.Array.concat(f(a), acc), [||], x);
 };
 
 module Foldable: FOLDABLE with type t('a) = array('a) = {
@@ -93,7 +93,7 @@ module Unfoldable: UNFOLDABLE with type t('a) = array('a) = {
 
   let rec unfold = (f, init) =>
     switch (f(init)) {
-    | Some((a, next)) => Js.Array.concat([|a|], unfold(f, next))
+    | Some((a, next)) => Js.Array.concat(unfold(f, next), [|a|])
     | None => [||]
     };
 };

--- a/bastet_js/src/JsArray.re
+++ b/bastet_js/src/JsArray.re
@@ -132,7 +132,8 @@ module Eq: Array.EQ_F =
   (E: EQ) => {
     type t = array(E.t);
     let eq = (xs, ys) =>
-      Js.Array.every(((a, b)) => E.eq(a, b), zip(xs, ys));
+      Js.Array.length(xs) == Js.Array.length(ys)
+      && Js.Array.every(((a, b)) => E.eq(a, b), zip(xs, ys));
   };
 
 module Ord: Array.ORD_F =

--- a/bastet_js/test/Test_JsArray.re
+++ b/bastet_js/test/Test_JsArray.re
@@ -21,7 +21,7 @@ module ArbitraryArrayInt:
 };
 
 module TestArray =
-  Test.Array(
+  Test.JsArray(
     MochaI.Test,
     JsVerifyI.Quickcheck,
     ArbitraryArrayInt,


### PR DESCRIPTION
resolves https://github.com/Risto-Stevcev/bastet/issues/28

This includes tests in the same vein as `bastet/src/Array` where applicable.

Per https://github.com/Risto-Stevcev/bastet/issues/28#issuecomment-603578667, I replaced calls to `Js.Array.concat` with calls to `Alt.alt`.