### PR TITLE
Fix docs of "bs-dependencies" BuckleScript config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ And add the dependency to your bs-dependencies in `bsconfig.json`:
 
 ```json
 "bs-dependencies": [
-  "bastet"
+  "bs-bastet"
 ]
 ```
 


### PR DESCRIPTION
Problem: documentation of how to configure in BuckleScript shows the non-working `"bastet"` instead of the working `"bs-bastet"` value to be used in the `bs-dependencies` configuration option.

Solution: replace it by the actually working version on the documentation file.