### PR TITLE
Add support for OCaml 4.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ env:
   - DISTRO="fedora" OCAML_VERSION="4.06"
   - DISTRO="ubuntu-lts" OCAML_VERSION="4.06"
   - DISTRO="alpine" OCAML_VERSION="4.06"
+  - DISTRO="debian-stable" OCAML_VERSION="4.12"

--- a/bastet/src/Array.rei
+++ b/bastet/src/Array.rei
@@ -95,7 +95,7 @@ module Extend: {
 };
 module Infix: {
   let (<$>): ('a => 'b, Monad.t('a)) => Monad.t('b);
-  let (<#>): (Monad.t('a), 'a => 'b) => Monad.t('b);
+  let (<@>): (Monad.t('a), 'a => 'b) => Monad.t('b);
   let (<*>): (Monad.t('a => 'b), Monad.t('a)) => Monad.t('b);
   let (>>=): (Monad.t('a), 'a => Monad.t('b)) => Monad.t('b);
   let (=<<): ('a => Monad.t('b), Monad.t('a)) => Monad.t('b);

--- a/bastet/src/ArrayF.re
+++ b/bastet/src/ArrayF.re
@@ -110,7 +110,7 @@ module type ARRAY = {
   };
   module Infix: {
     let (<$>): ('a => 'b, Monad.t('a)) => Monad.t('b);
-    let (<#>): (Monad.t('a), 'a => 'b) => Monad.t('b);
+    let (<@>): (Monad.t('a), 'a => 'b) => Monad.t('b);
     let (<*>): (Monad.t('a => 'b), Monad.t('a)) => Monad.t('b);
     let (>>=): (Monad.t('a), 'a => Monad.t('b)) => Monad.t('b);
     let (=<<): ('a => Monad.t('b), Monad.t('a)) => Monad.t('b);

--- a/bastet/src/Infix.re
+++ b/bastet/src/Infix.re
@@ -10,7 +10,7 @@ module Magma_Any = (M: MAGMA_ANY) => {
 
 module Functor = (F: FUNCTOR) => {
   let (<$>) = F.map
-  and (<#>) = (f, x) => F.map(x, f);
+  and (<@>) = (f, x) => F.map(x, f);
 };
 
 module Apply = (A: APPLY) => {


### PR DESCRIPTION
The latest release of bastet currently fails with OCaml 4.12:
```
#=== ERROR while compiling bastet.1.2.5 =======================================#
# context              2.1.0~beta4 | linux/x86_64 | ocaml-variants.4.12.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.12.0+trunk/.opam-switch/build/bastet.1.2.5
# command              ~/.opam/4.12.0+trunk/bin/dune build -p bastet -j 71 @install
# exit-code            1
# env-file             ~/.opam/log/bastet-8-8347bb.env
# output-file          ~/.opam/log/bastet-8-8347bb.out
### output ###
#       ocamlc bastet/src/.bastet.objs/byte/bastet__Array.{cmi,cmti} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12.0+trunk/bin/ocamlc.opt -w -40 -g -bin-annot -I bastet/src/.bastet.objs/byte -no-alias-deps -open Bastet -o bastet/src/.bastet.objs/byte/bastet__Array.cmi -c -intf bastet/src/Array.rei.mli)
# File "bastet/src/Array.rei", line 98, characters 2-51:
# 98 |   let (<#>): (Monad.t('a), 'a => 'b) => Monad.t('b);
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: '<#>' is not a valid value identifier.
#       ocamlc bastet/src/.bastet.objs/byte/bastet__Infix.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12.0+trunk/bin/ocamlc.opt -w -40 -g -bin-annot -I bastet/src/.bastet.objs/byte -no-alias-deps -open Bastet -o bastet/src/.bastet.objs/byte/bastet__Infix.cmo -c -impl bastet/src/Infix.re.ml)
# File "bastet/src/Infix.re", line 13, characters 6-11:
# 13 |   and (<#>) = (f, x) => F.map(x, f);
#            ^^^^^
# Error: '<#>' is not a valid value identifier.
```
The issue is that `<#>` was never a valid OCaml operator to begin with but Reason bypassed the check in the past, however in OCaml 4.12 the checks have been harden so this isn't allowed anymore.